### PR TITLE
Moisture sensor analog calibration utility

### DIFF
--- a/utilities/moisture_sensor_calibration/moisture_sensor_calibration.ino
+++ b/utilities/moisture_sensor_calibration/moisture_sensor_calibration.ino
@@ -1,0 +1,173 @@
+/*    
+    moisture_sensor_calibration.ino (v 1.0) - Sketch with helpers for resistive moisture sensor analog 
+    calibration.
+
+    Program will start in WRITE mode with range set to manufacturer's specification.
+
+    When switching to RECORD mode you need to dip the probe into a glass of water, remove, 
+    rinse and repeat as many times as you feel necessary. This will calculate the upper and 
+    lower bounds of your particular probe. 
+    
+    These values are also updated in the map function which allows you to test them out after 
+    recording is complete.
+
+    If upper and lower bounds are accurate you should see values from 0%-5% when dipped into 
+    water and 97%-100% when removed.
+
+    Instructions:
+    - Program will start in WRITE state. This state outputs changes in moisture readings to serial
+      as a percentage of dryness. 
+    - Dip the probe into a glass of water to measure deviation from factory defaults. If no deviation
+      then a value of 100% out of water and 0%-5% in water is returned.
+    - Send a 'R' or 'r' (without ') character to board via serial port to switch to RECORD state
+    - This state will display and store upper and lower bounds of probe as it is dipped into water
+    - When satisfied that new bounds are read (dipping the probe once or twice is sufficient) send
+      a 'S' or 's' to set new bounds, display values and switch back to WRITE. These values can
+      be used to define the upper and lower readings of your sensor
+    - Dip probe into water once or twice to confirm readings.
+
+    Notes:
+    - Tested on:
+      - Arduino Duemilanove
+      - Arduino Uno R3
+      - Arduino Mega 2560 R3
+      - Arduino Nano v3
+      - Arduino Leonardo R3
+      - NodeMCU 1.0 (ESP8266)
+    - ESP8266 serial behavior might prevent initial outputs from being delivered to serial even after 
+      call to !Serial. Not necessarily a problem if initial readings don't appear for ESP8266. You 
+      can proceed to dip the probe and see if values are updated on screen.
+      
+    Created by Rénaldo Meere, 24 February 2021
+    Released into the public domain
+*/
+
+#include <Arduino.h>
+#include "state.h"
+
+#define SENSOR_ANALOG_PIN A0
+
+enum state
+{
+  STATE_IDLE,
+  STATE_RECORDING,  
+  STATE_WRITE_PERCENTAGE,
+};
+
+state currentState = STATE_WRITE_PERCENTAGE;
+
+int minReading = 0;
+int maxReading = 1023;
+int lastReading = 101; //Put this out of range so sensor is forced to take first reading and update
+
+void setup()
+{
+  Serial.begin(115200);
+  pinMode(SENSOR_ANALOG_PIN, INPUT);
+  while (!Serial)  
+  {
+    delay(10);
+  }  
+}
+
+void loop()
+{
+  if (Serial.available() > 0)
+    readForNewState();
+
+  if (currentState == STATE_WRITE_PERCENTAGE)
+  {
+    writePercentageReadings();   
+  }
+  else if (currentState == STATE_RECORDING)
+  {
+    recordReadings();     
+  }
+
+  delay(100);
+}
+
+String getStateDescription(state state)
+{
+  switch (state)
+  {
+  case STATE_RECORDING:
+    return "RECORDING";
+  case STATE_WRITE_PERCENTAGE:
+    return "WRITING PERCENTAGES";
+  default:
+    return "IDLE";
+  }
+}
+
+void readForNewState()
+{
+  char value = Serial.read();
+
+  if ((value == 'R' || value == 'r') && currentState != STATE_RECORDING)
+  {
+    switchToRecording();
+  }
+  else if ((value == 'S' || value == 's') && currentState == STATE_RECORDING)
+  {    
+    Serial.println("State changed to STOP RECORDING, CALCULATING");
+    printoutRangeReadings();
+  }  
+  else if ((value == 'W' || value == 'w') && currentState != STATE_WRITE_PERCENTAGE)
+  {
+    Serial.println("State changed to WRITING PERCENTAGES");
+  }
+}
+
+void switchToWriting()
+{
+  currentState = STATE_WRITE_PERCENTAGE;  
+  Serial.println("State changed to " + getStateDescription(currentState));  
+}
+
+void writePercentageReadings()
+{
+  int value = analogRead(SENSOR_ANALOG_PIN);
+
+  value = map(value, minReading, maxReading, 0, 100);
+  
+  if (value != lastReading)
+  {    
+    lastReading = value;
+    Serial.println((String)"Dryness (percentage): " + value);
+  }
+}
+
+void switchToRecording()
+{
+  currentState = STATE_RECORDING;
+  minReading = 1023;
+  maxReading = 0;
+  
+  Serial.println("State changed to " + getStateDescription(currentState));
+  Serial.println("Dip the probe into a glass of water and remove it. Repeat this until you are satisfied, twice should generally be enough");
+}
+
+void recordReadings()
+{
+  int value = analogRead(SENSOR_ANALOG_PIN);
+  
+  if (value < minReading)
+  {
+    minReading = value;
+    Serial.println((String)"New lower bound: " + minReading);
+  }
+  else if (value > maxReading)
+  {
+    maxReading = value;
+    Serial.println((String)"New upper bound: " + maxReading);
+  }
+}
+
+void printoutRangeReadings()
+{
+  Serial.println("");
+  Serial.println((String)"Highest reading (sensor upper range): " + maxReading);
+  Serial.println((String)"Lowest reading (sensor lower range): " + minReading);
+  switchToWriting();
+}

--- a/utilities/moisture_sensor_calibration_by_Renaldo_Meere.md
+++ b/utilities/moisture_sensor_calibration_by_Renaldo_Meere.md
@@ -1,0 +1,79 @@
+# Read upper and lower bounds from resistive soil sensor
+Author - Rénaldo Meere.
+Version - 1.0.
+Date - 26 February 2021.
+Released into the public domain.
+
+## What you will need
+1. Your Make kit with ESP8266 NodeMCU.
+2. Soil sensor connected to 3V, G and A0 as per wiring diagram (note that digital is not used in the example).
+3. A glass of water for calibration.
+4. moisture_sensor_calibration.ino
+
+## Introduction
+By default, the soil sensor included in the kit is set to work with an analogue read range of 0 - 1023 indicating values of completely-wet to completely-dry. This is achieved by measuring the resistance between the two ends of the probe. 
+
+Due to a difference in manufacturing techniques, as well as a range of environmental and equipment factors, some sensors do not achieve the minimum and maximum bounds. Generally, this does not constitute a problem, but it does need to be considered if you want to make use of the analogue readings to get incremental values of soil moisture.
+
+It is possible in some cases to achieve these values by adjusting the potentiometer located on the sensor but on some hardware, this will not be sufficient to achieve readings between 0 and 1023.
+
+This utility assists with identifying the upper and lower bounds that the connected sensor achieves by recording these values and reporting them back for easy reference.
+
+It also allows you to test the readings after the range has been identified to make sure that they correspond to the correct settings.
+
+## How to use this utility
+1. Start by connecting the resistive sensor pins for 3V, G and A0.
+2. Upload the sketch to your Arduino Board.
+3. Open the serial monitor and make sure it is set to a baud rate of 115200.
+3. Dip the moisture sensor probe in the glass of water and confirm that the values printed in serial monitor change as the probe is inserted and removed. *NB: be careful to not insert the probe too far past the portion where the metal circuit is exposed on the circuit board. Inserting it up to the point where the jumper is connected could cause a short circuit. Stop before reaching this point*
+4. If you are getting readings of 100 down to 0 when doing this then you probably don’t need to calibrate your setup.
+5. To start calibrating, use the serial monitor and send the character ‘R’ (without ‘) to the board. You should get a message telling you that the board has entered a RECORDING state.
+6. Repeat step 3 a few times. Generally once or twice is enough.
+7. Once you are satisfied that the sensor was immersed completely a few times you can use the serial monitor again and send the character ‘S’.
+8. Your board will exit the RECORDING state and display the new bounds that were discovered. Write down these values because they indicate the upper and lower bounds of your particular setup.
+9. The firmware will also update the variables used in the map function to reflect these new values. *NB: These values reset to original values when the board is reset. They are not retained because the starting values are flashed as part of the firmware. You need to repeat from Step 1 if you reset the board*
+10. Repeat step 3 to make sure that you are able to get readings between 0%-5% and 95%- 100%.
+
+## Reading the moisture value
+The moisture value is mapped as a range between 0 and 100 and indicates how dry the sensor is. This is achieved by using the map() function built into the standard Arduino library.
+
+For more information: https://www.arduino.cc/reference/en/language/functions/math/map/
+
+Initially the upper bound of this range is set to 1023 and the lower bound to 0. 
+
+Factory defaults translate to:
+-	A value of 1023 would translate to a moisture reading of 100% dry.
+-	A value of 0 would translate to a moisture reading of 0% dry.
+-	A value of 512 would translate to a moisture reading of 50% dry.
+
+After running the RECORD function at least once, these values are updated to reflect the upper and lower bounds of your particular sensor and the input to the map() function will be updated to reflect this. Here is an example to demonstrate how your readings *might* look once done.
+
+-	A value of 654 would translate to a moisture reading of 100% dry.
+-	A value of 124 would translate to a moisture reading of 0% dry.
+-	A value of 389 would translate to a moisture reading of 50% dry.
+
+## Notes and general observations
+Tested on the following boards:
+- Arduino Duemilanove
+- Arduino Uno R3 with Ethernet shield
+- Arduino Mega 2560 R3
+- Arduino Nano v3 with Ethernet shield
+- Arduino Leonardo R3
+- NodeMCU 1.0 (ESP8266)
+
+ESP8266 serial behaviour might prevent initial outputs from being delivered to serial even after the call to (!Serial). Not necessarily a problem if initial readings do not appear for ESP8266. You can proceed to dip the probe and see if values are updated on screen. This was not a problem on other Arduino boards and seems to be isolated to the way the ESP8266 serial behaviour is handled in particular.
+
+In rare cases your sensor readings might be inverted so that 0 means it is completely wet. The map() function will still work in these instances to indicate the moisture but you'd need to consider that it displays "wetness" instead of "dryness".
+
+## Troubleshooting
+### No readings when dipping probe into liquid
+Confirm wiring of the sensor:
+- Sensor VCC -> ESP8266 3V
+- Sensor GND -> ESP8266 G
+- Sensor A0 -> ESP8266 A0
+
+### Garbage / unreadable characters in serial monitor printout
+Make sure that serial monitor baud rate is set to 115200
+
+### Negative readings of moisture
+Sensor might be using inverted configuration where completely dry could translate to 0. You can still use this utility and ignore the -


### PR DESCRIPTION
Stand-alone utility sketch (plus appropriate .md file containing usage instructions) to assist with calibrating upper and lower bounds of moisture sensor analog reads.